### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Setting up your FB Messenger Bot
 You can follow the instructions provided here: https://developers.facebook.com/docs/messenger-platform/quickstart.  
-- [YouPin App](https://developers.facebook.com/apps/1590826994566376), linked to the official [YouPin Page](www.facebook.com/youpin.city)
+- [YouPin App](https://developers.facebook.com/apps/1590826994566376), linked to the official [YouPin Page](https://www.facebook.com/youpin.city)
 - [YouPin Test App](https://developers.facebook.com/apps/266788757017683) (for development/testing), linked to the [YouPin Test Page](https://www.facebook.com/youpin.city.test)
 
 If you fork this repo for other applications, you will need to create a new Facebook App and/or Page first.


### PR DESCRIPTION
An external link must be prepended with http(s).
